### PR TITLE
Ensure `debugNeedsPaint` is used only in debug mode

### DIFF
--- a/lib/src/snapshot/snapshot_builder.dart
+++ b/lib/src/snapshot/snapshot_builder.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
@@ -119,7 +120,7 @@ class _SnapshotBuilderState extends State<SnapshotBuilder> {
       RenderRepaintBoundary? boundary = _containerKey.currentContext
           ?.findRenderObject() as RenderRepaintBoundary?;
 
-      if (boundary == null || boundary.debugNeedsPaint) {
+      if (boundary == null || (kDebugMode && boundary.debugNeedsPaint)) {
         completer.complete(null);
         return;
       }


### PR DESCRIPTION
The `debugNeedsPaint` getter is only available in debug mode, which caused the animation to stop working in release mode due to the uninitialized variable.

This change resolves the issue introduced in #6 by restricting the use of debugNeedsPaint to debug mode only.